### PR TITLE
Fix some issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=${BUILDPLATFORM} ubuntu:22.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 RUN \
@@ -14,7 +14,7 @@ RUN \
   apt-get -y clean && \
   rm -rf /var/lib/apt/lists/* 
 
-ENV GOSU_VERSION 1.17
+ENV GOSU_VERSION=1.17
 RUN set -eux; \
   # save list of currently installed packages for later so we can clean up
     savedAptMark="$(apt-mark showmanual)"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,7 @@ RUN \
   apt-get upgrade -y && \
   apt-get -y install \
     ca-certificates curl sudo xorg dbus dbus-x11 ubuntu-gnome-default-settings gtk2-engines \
-    fonts-freefont-ttf fonts-ubuntu-console fonts-droid-fallback lxappearance && \
-  apt-get autoclean && \
-  apt-get autoremove && \
-  apt-get -y clean && \
-  rm -rf /var/lib/apt/lists/* 
+    fonts-freefont-ttf fonts-ubuntu-console fonts-droid-fallback lxappearance
 
 ENV GOSU_VERSION=1.17
 RUN set -eux; \
@@ -42,3 +38,9 @@ RUN set -eux; \
   # verify that the binary works
     gosu --version; \
     gosu nobody true
+  
+RUN \
+  apt-get autoclean && \
+  apt-get autoremove && \
+  apt-get -y clean && \
+  rm -rf /var/lib/apt/lists/* 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/x86_64 ubuntu:22.04
+FROM --platform=${BUILDPLATFORM} ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Dockerfile for Ubuntu 22.04 on x86_64 with xorg.
 4. Restart macOS.
 7. `git clone https://github.com/zacky1972/docker-ubuntu22-xorg.git`
 8. `cd docker-ubuntu22-xorg`
-9. `docker image build --rm --no-cache --pull -t zacky1972/ubuntu22-xorg .`
+9. `BUILDPLATFORM="linux/amd64" docker image build --rm --no-cache --pull -t zacky1972/ubuntu22-xorg .`
 
 ## Usage (to run `xclock`)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dockerfile for Ubuntu 22.04 on x86_64 with xorg.
 
 ## Installation
 
-1. `brew install orbstack xquartz`
+1. `brew install xquartz`
 2. `open -a XQuartz`
 3. Open the XQuartz setting in Security, allow connections from network clients.
 4. Restart macOS.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Dockerfile for Ubuntu 22.04 on x86_64 with xorg.
 4. Restart macOS.
 7. `git clone https://github.com/zacky1972/docker-ubuntu22-xorg.git`
 8. `cd docker-ubuntu22-xorg`
-9. `BUILDPLATFORM="linux/amd64" docker image build --rm --no-cache --pull -t zacky1972/ubuntu22-xorg .`
+9. `BUILDPLATFORM="linux/amd64" docker image build --rm --no-cache --pull -t zacky1972/ubuntu22-xorg-x86_64 .`
 
 ## Usage (to run `xclock`)
 
 1. `open -a XQuartz`
 2. `xhost + localhost`
-3. `docker run --env="DISPLAY=host.docker.internal:0" --detach zacky1972/ubuntu22-xorg xclock`
+3. `docker run --env="DISPLAY=host.docker.internal:0" --detach zacky1972/ubuntu22-xorg-x86_64 xclock`
 
 ## License
 


### PR DESCRIPTION
* Remove description of OrbStack in README.
* Fix an issue on FromPlatformFlagConstDisallowed.
* Fix issues on LegacyKeyValueFormat.
* Fix an issue on the warning when running the image.
* Fix an issue on removing `apt` cache.

```bash
 - FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/x86_64" (line 1)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 17)
```

```bash
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```